### PR TITLE
Improve kernel interrupt handling and tests

### DIFF
--- a/pytests/test_debugger_suite.py
+++ b/pytests/test_debugger_suite.py
@@ -1,7 +1,6 @@
 import time, pytest
 from contextlib import contextmanager
-from .kernel_utils import (DEBUG_INIT_ARGS, debug_configuration_done, debug_continue, debug_dump_cell,
-    debug_info, debug_request, debug_set_breakpoints, get_shell_reply, start_kernel, wait_for_stop)
+from .kernel_utils import DEBUG_INIT_ARGS, debug_configuration_done, debug_dump_cell, debug_set_breakpoints, start_kernel, wait_for_stop
 
 TIMEOUT = 3
 
@@ -11,42 +10,15 @@ def new_kernel():
     with start_kernel() as (_km, kc): yield kc
 
 
-def prepare_debug_request(kernel, command, arguments=None, **kwargs):
-    if arguments is None: arguments = {}
-    if kwargs: arguments |= kwargs
-    seq = getattr(kernel, "_debug_seq", 1)
-    setattr(kernel, "_debug_seq", seq + 1)
-    msg = kernel.session.msg("debug_request", dict(type="request", seq=seq, command=command, arguments=arguments or {}))
-    return msg
+def get_stack_frames(dap, thread_id): return dap.stackTrace(threadId=thread_id)["body"]["stackFrames"]
 
-
-def wait_for_debug_request(kernel, command, arguments=None, full_reply=False, **kwargs):
-    if arguments is None: arguments = {}
-    if kwargs: arguments |= kwargs
-    return debug_request(kernel, command, arguments, full_reply=full_reply)
-
-
-def get_stack_frames(kernel, thread_id):
-    return wait_for_debug_request(kernel, "stackTrace", threadId=thread_id)["body"]["stackFrames"]
-
-def get_scopes(kernel, frame_id): return wait_for_debug_request(kernel, "scopes", frameId=frame_id)["body"]["scopes"]
+def get_scopes(dap, frame_id): return dap.scopes(frameId=frame_id)["body"]["scopes"]
 
 def get_scope_ref(scopes, name): return next(s for s in scopes if s["name"] == name)["variablesReference"]
 
-def get_scope_vars(kernel, scopes, name):
+def get_scope_vars(dap, scopes, name):
     ref = get_scope_ref(scopes, name)
-    return wait_for_debug_request(kernel, "variables", variablesReference=ref)["body"]["variables"]
-
-
-def get_replies(kernel, msg_ids):
-    replies = {msg_id: None for msg_id in msg_ids}
-    deadline = time.time() + TIMEOUT
-    while time.time() < deadline and any(v is None for v in replies.values()):
-        reply = kernel.control_channel.get_msg(timeout=TIMEOUT)
-        msg_id = reply["parent_header"].get("msg_id")
-        if msg_id in replies: replies[msg_id] = reply
-    if any(v is None for v in replies.values()): raise AssertionError("timeout waiting for debug replies")
-    return [replies[msg_id] for msg_id in msg_ids]
+    return dap.variables(variablesReference=ref)["body"]["variables"]
 
 
 def ensure_configuration_done(kernel) -> None:
@@ -57,10 +29,12 @@ def ensure_configuration_done(kernel) -> None:
 
 
 def continue_debugger(kernel, stopped: dict) -> None:
+    dap = kernel.dap
+    cont = getattr(dap, "continue")
     body = stopped.get("content", {}).get("body", {})
     thread_id = body.get("threadId")
-    if isinstance(thread_id, int): debug_continue(kernel, thread_id)
-    else: debug_continue(kernel)
+    if isinstance(thread_id, int): cont(threadId=thread_id)
+    else: cont()
 
 
 @pytest.fixture()
@@ -70,21 +44,22 @@ def kernel():
 
 @pytest.fixture()
 def debug_kernel(kernel):
-    reply = wait_for_debug_request(kernel, "initialize", DEBUG_INIT_ARGS)
+    reply = kernel.dap.initialize(**DEBUG_INIT_ARGS)
     assert reply.get("success"), f"initialize failed: {reply}"
-    reply = wait_for_debug_request(kernel, "attach")
+    reply = kernel.dap.attach()
     assert reply.get("success"), f"attach failed: {reply}"
     try: yield kernel
-    finally: wait_for_debug_request(kernel, "disconnect", restart=False, terminateDebuggee=True)
+    finally: kernel.dap.disconnect(restart=False, terminateDebuggee=True)
 
 
 def test_debugger_basic_features(debug_kernel):
-    debug_kernel.kernel_info()
-    reply = debug_kernel.get_shell_msg(timeout=TIMEOUT)
+    dap = debug_kernel.dap
+    msg_id = debug_kernel.kernel_info()
+    reply = debug_kernel.shell_reply(msg_id)
     features = reply["content"].get("supported_features", [])
     assert "debugger" in features, f"supported_features: {features}"
 
-    reply = wait_for_debug_request(debug_kernel, "evaluate", expression="'a' + 'b'", context="repl")
+    reply = dap.evaluate(expression="'a' + 'b'", context="repl")
     assert reply.get("success"), f"evaluate failed: {reply}"
     assert reply["body"]["result"] == "", f"evaluate result: {reply['body']['result']}"
 
@@ -93,11 +68,12 @@ def test_debugger_basic_features(debug_kernel):
     code = f"{var_name}='{value}'\nprint({var_name})\n"
     debug_kernel.execute(code)
     debug_kernel.get_shell_msg(timeout=TIMEOUT)
-    wait_for_debug_request(debug_kernel, "inspectVariables")
-    wait_for_debug_request(debug_kernel, "richInspectVariables", variableName=var_name)
+    dap.inspectVariables()
+    dap.richInspectVariables(variableName=var_name)
 
 
 def test_debugger_breakpoints_and_steps(debug_kernel):
+    dap = debug_kernel.dap
     code = """
 def f(a, b):
     c = a + b
@@ -117,55 +93,51 @@ g()
     stopped = wait_for_stop(debug_kernel)
     assert stopped["content"]["body"]["reason"] == "breakpoint", f"stopped: {stopped}"
     thread_id = stopped["content"]["body"].get("threadId", 1)
-    stepped = wait_for_debug_request(debug_kernel, "stepIn", threadId=thread_id)
+    stepped = dap.stepIn(threadId=thread_id)
     assert stepped.get("success"), f"stepIn failed: {stepped}"
     stopped = wait_for_stop(debug_kernel)
     thread_id = stopped["content"]["body"].get("threadId", thread_id)
-    frames = get_stack_frames(debug_kernel, thread_id)
+    frames = get_stack_frames(dap, thread_id)
     assert frames and frames[0]["name"] == "f", f"frames: {frames}"
 
-    reply = wait_for_debug_request(debug_kernel, "next", threadId=thread_id)
+    reply = dap.next(threadId=thread_id)
     assert reply.get("success"), f"next failed: {reply}"
     stopped = wait_for_stop(debug_kernel)
     thread_id = stopped["content"]["body"].get("threadId", thread_id)
-    frames = get_stack_frames(debug_kernel, thread_id)
+    frames = get_stack_frames(dap, thread_id)
     frame_id = frames[0]["id"]
-    scopes = get_scopes(debug_kernel, frame_id)
-    locals_ = get_scope_vars(debug_kernel, scopes, "Locals")
+    scopes = get_scopes(dap, frame_id)
+    locals_ = get_scope_vars(dap, scopes, "Locals")
     local_names = [v["name"] for v in locals_]
     assert "a" in local_names and "b" in local_names, f"locals: {locals_}"
 
-    reply = wait_for_debug_request(debug_kernel, "richInspectVariables", variableName=locals_[0]["name"], frameId=frame_id)
+    reply = dap.richInspectVariables(variableName=locals_[0]["name"], frameId=frame_id)
     assert reply.get("success"), f"richInspectVariables failed: {reply}"
 
-    reply = wait_for_debug_request(debug_kernel, "copyToGlobals", srcVariableName="c", dstVariableName="c_copy",
-        srcFrameId=frame_id)
+    reply = dap.copyToGlobals(srcVariableName="c", dstVariableName="c_copy", srcFrameId=frame_id)
     assert reply.get("success"), f"copyToGlobals failed: {reply}"
-    globals_ = get_scope_vars(debug_kernel, scopes, "Globals")
+    globals_ = get_scope_vars(dap, scopes, "Globals")
     assert any(v for v in globals_ if v["name"] == "c_copy"), f"globals: {globals_}"
 
     locals_ref = get_scope_ref(scopes, "Locals")
     globals_ref = get_scope_ref(scopes, "Globals")
-    msgs = [prepare_debug_request(debug_kernel, "variables", variablesReference=locals_ref),
-        prepare_debug_request(debug_kernel, "variables", variablesReference=globals_ref)]
-    for msg in msgs: debug_kernel.control_channel.send(msg)
-    replies = get_replies(debug_kernel, [msg["header"]["msg_id"] for msg in msgs])
-    locals_reply = replies[0]["content"]
-    globals_reply = replies[1]["content"]
+    locals_reply = dap.variables(variablesReference=locals_ref)
+    globals_reply = dap.variables(variablesReference=globals_ref)
     assert locals_reply["success"], f"locals reply: {locals_reply}"
     assert globals_reply["success"], f"globals reply: {globals_reply}"
-    reply = wait_for_debug_request(debug_kernel, "stepOut", threadId=thread_id)
+    reply = dap.stepOut(threadId=thread_id)
     assert reply.get("success"), f"stepOut failed: {reply}"
     stopped = wait_for_stop(debug_kernel)
     thread_id = stopped["content"]["body"].get("threadId", thread_id)
-    frames = get_stack_frames(debug_kernel, thread_id)
+    frames = get_stack_frames(dap, thread_id)
     assert frames and frames[0]["name"] != "f", f"frames: {frames}"
 
     continue_debugger(debug_kernel, stopped)
 
 
 def test_debugger_exceptions_and_terminate(debug_kernel):
-    reply = wait_for_debug_request(debug_kernel, "setExceptionBreakpoints", filters=["raised"])
+    dap = debug_kernel.dap
+    reply = dap.setExceptionBreakpoints(filters=["raised"])
     assert reply["success"], f"setExceptionBreakpoints failed: {reply}"
     ensure_configuration_done(debug_kernel)
     msg_id = debug_kernel.execute("raise ValueError('boom')")
@@ -173,11 +145,11 @@ def test_debugger_exceptions_and_terminate(debug_kernel):
     reason = stopped["content"]["body"].get("reason")
     assert reason in {"exception", "breakpoint", "pause"}, f"stopped: {stopped}"
     continue_debugger(debug_kernel, stopped)
-    reply = get_shell_reply(debug_kernel, msg_id)
+    reply = debug_kernel.shell_reply(msg_id)
     assert reply["content"]["status"] == "error", f"execute reply: {reply.get('content')}"
 
-    reply = wait_for_debug_request(debug_kernel, "terminate", restart=False)
+    reply = dap.terminate(restart=False)
     assert reply["success"], f"terminate failed: {reply}"
-    info = debug_info(debug_kernel)
+    info = dap.debugInfo()
     assert info["body"]["breakpoints"] == [], f"breakpoints not cleared: {info['body']['breakpoints']}"
     assert info["body"]["stoppedThreads"] == [], f"stoppedThreads not cleared: {info['body']['stoppedThreads']}"

--- a/pytests/test_gateway_interrupt.py
+++ b/pytests/test_gateway_interrupt.py
@@ -7,8 +7,8 @@ from .kernel_utils import TIMEOUT, build_env, ensure_separate_process
 
 
 async def _wait_for_status(kc, state: str, timeout: float) -> dict:
-    deadline = time.time() + timeout
-    while time.time() < deadline:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
         msg = await kc.get_iopub_msg(timeout=0.2)
         if msg.get("msg_type") == "status" and msg.get("content", {}).get("execution_state") == state: return msg
     raise AssertionError(f"timeout waiting for status {state}")

--- a/pytests/test_kernel_basic.py
+++ b/pytests/test_kernel_basic.py
@@ -1,10 +1,9 @@
-from .kernel_utils import drain_iopub, get_shell_reply, iopub_msgs, start_kernel
+from .kernel_utils import iopub_msgs, start_kernel
 
 
 def test_execute_stream() -> None:
     with start_kernel() as (_, kc):
-        msg_id = kc.execute("print('hello')", store_history=False)
-        outputs = drain_iopub(kc, msg_id)
+        _, _, outputs = kc.exec_ok("print('hello')", store_history=False)
         stream = iopub_msgs(outputs, "stream")
         assert stream, "expected stream output"
         assert stream[-1]["content"]["text"].strip() == "hello"

--- a/pytests/test_kernel_connect.py
+++ b/pytests/test_kernel_connect.py
@@ -1,12 +1,10 @@
-from .kernel_utils import get_shell_reply, load_connection, start_kernel
+from .kernel_utils import load_connection, start_kernel
 
 
 def test_connect_request() -> None:
     with start_kernel() as (km, kc):
-        msg = kc.session.msg("connect_request", content={})
-        kc.shell_channel.send(msg)
-        msg_id = msg["header"]["msg_id"]
-        reply = get_shell_reply(kc, msg_id)
+        msg_id = kc.cmd.connect_request()
+        reply = kc.shell_reply(msg_id)
         content = reply["content"]
         conn = load_connection(km)
 

--- a/pytests/test_kernel_interrupt.py
+++ b/pytests/test_kernel_interrupt.py
@@ -1,21 +1,7 @@
 import time, asyncio, os
 from queue import Empty
 from jupyter_client import AsyncKernelClient, KernelManager
-from .kernel_utils import build_env, drain_iopub, ensure_separate_process, get_shell_reply, iopub_msgs, start_kernel, wait_for_status
-
-
-def _send_interrupt_request(kc) -> None:
-    interrupt_msg = kc.session.msg("interrupt_request", {})
-    kc.control_channel.send(interrupt_msg)
-    deadline = time.time() + 2
-    interrupt_reply = None
-    while time.time() < deadline:
-        reply = kc.control_channel.get_msg(timeout=2)
-        if reply["parent_header"].get("msg_id") == interrupt_msg["header"]["msg_id"]:
-            interrupt_reply = reply
-            break
-    assert interrupt_reply is not None, "missing interrupt_reply"
-    assert interrupt_reply["header"]["msg_type"] == "interrupt_reply"
+from .kernel_utils import build_env, ensure_separate_process, iopub_msgs, start_kernel, wait_for_status
 
 
 async def _get_pubs(kc: AsyncKernelClient, timeout: float = 0.2) -> list[dict]:
@@ -32,16 +18,16 @@ def test_interrupt_request() -> None:
             msg_id = kc.execute("import time; time.sleep(1)")
             wait_for_status(kc, "busy")
 
-            if use_control_channel: _send_interrupt_request(kc)
+            if use_control_channel: kc.interrupt_request()
             else: km.interrupt_kernel()
 
-            reply = get_shell_reply(kc, msg_id, timeout=10)
+            reply = kc.shell_reply(msg_id, timeout=10)
             assert reply["content"]["status"] == "error", f"interrupt reply: {reply.get('content')}"
             assert reply["content"].get("ename") in {"KeyboardInterrupt", "InterruptedError"}, (
                 f"interrupt ename: {reply.get('content')}"
             )
 
-            outputs = drain_iopub(kc, msg_id)
+            outputs = kc.iopub_drain(msg_id)
             errors = iopub_msgs(outputs, "error")
             assert errors, f"expected iopub error after interrupt, got: {[m.get('msg_type') for m in outputs]}"
             assert errors[-1]["content"].get("ename") == "KeyboardInterrupt", (
@@ -53,11 +39,11 @@ def test_interrupt_request_breaks_sleep() -> None:
     with start_kernel() as (_, kc):
         msg_id = kc.execute("import time; time.sleep(5); print('finished')")
         wait_for_status(kc, "busy")
-        _send_interrupt_request(kc)
-        try: reply = get_shell_reply(kc, msg_id, timeout=2)
+        kc.interrupt_request()
+        try: reply = kc.shell_reply(msg_id, timeout=2)
         except Exception as exc: raise AssertionError("expected execute_reply after interrupt_request") from exc
         assert reply["content"]["status"] == "error", f"interrupt reply: {reply.get('content')}"
-        outputs = drain_iopub(kc, msg_id)
+        outputs = kc.iopub_drain(msg_id)
         errors = iopub_msgs(outputs, "error")
         assert errors, f"expected iopub error after interrupt_request, got: {[m.get('msg_type') for m in outputs]}"
         assert errors[-1]["content"].get("ename") == "KeyboardInterrupt", (
@@ -77,12 +63,10 @@ def test_interrupt_request_gateway_pattern() -> None:
         kc.start_channels()
         await kc.wait_for_ready(timeout=2)
         try:
-            msg = kc.session.msg("execute_request", {"code": "import time; time.sleep(1); print('finished')"})
-            kc.shell_channel.send(msg)
-            msg_id = msg["header"]["msg_id"]
+            cmd = kc.cmd
+            msg_id = cmd.execute_request(code="import time; time.sleep(1); print('finished')")
             await asyncio.sleep(0.2)
-            interrupt_msg = kc.session.msg("interrupt_request", {})
-            kc.control_channel.send(interrupt_msg)
+            await kc.interrupt_request_async(timeout=2)
             await asyncio.sleep(0.2)
             pubs = await _get_pubs(kc, timeout=0.2)
             outs = [o for o in pubs if o.get("parent_header", {}).get("msg_id") == msg_id]

--- a/pytests/test_kernel_minimal_behaviors.py
+++ b/pytests/test_kernel_minimal_behaviors.py
@@ -16,8 +16,8 @@ def _send_kernel_info(session: Session, sock: zmq.Socket) -> None: session.send(
 
 
 def _recv_kernel_info(session: Session, sock: zmq.Socket, timeout: float) -> dict | None:
-    deadline = time.time() + timeout
-    while time.time() < deadline:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
         if not sock.poll(50): continue
         try: _, msg = session.recv(sock, mode=0)
         except Exception: return None

--- a/tools/pr.sh
+++ b/tools/pr.sh
@@ -3,12 +3,21 @@ set -e
 
 label=${1:-enhancement}  # enhancement or bug
 msg=${2:-"Update"}
+body=${3:-""}
 
 branch="pr-$(date +%s)"
 git checkout -b "$branch"
 git commit -am "$msg"
 git push -u origin "$branch"
-gh pr create --fill --label "$label"
+if [ -n "$body" ]; then
+  if [ -f "$body" ]; then
+    gh pr create --title "$msg" --body-file "$body" --label "$label"
+  else
+    gh pr create --title "$msg" --body "$body" --label "$label"
+  fi
+else
+  gh pr create --fill --label "$label"
+fi
 gh pr merge --squash --auto
 git checkout main
 


### PR DESCRIPTION
## Summary
- Send busy/idle manually in execute to guarantee error/idle handling when interrupts happen during reply send.
- Add/extend kernel client test helpers (cmd/dap, reply/interrupt helpers) and update tests to use them.
- Add temp env helper for tests and apply it to the matplotlib cache test; increase timeout for inline backend.
- Fix subshell fuzz test loop indentation regression.

## Tests
- pytest -q
- pytest -q -m slow
