### PR TITLE
Refine timeout helpers and tests

### DIFF
--- a/pytests/test_kernel_iopub.py
+++ b/pytests/test_kernel_iopub.py
@@ -13,9 +13,8 @@ def test_iopub_welcome() -> None:
         sub.setsockopt(zmq.SUBSCRIBE, b"")
         sub.connect(f"{conn['transport']}://{conn['ip']}:{conn['iopub_port']}")
 
-        deadline = time.monotonic() + 5
         msg = None
-        while time.monotonic() < deadline:
+        for _ in iter_timeout(5):
             try: frames = sub.recv_multipart(flags=zmq.NOBLOCK)
             except zmq.Again:
                 time.sleep(0.05)

--- a/pytests/test_kernel_minimal_behaviors.py
+++ b/pytests/test_kernel_minimal_behaviors.py
@@ -16,8 +16,7 @@ def _send_kernel_info(session: Session, sock: zmq.Socket) -> None: session.send(
 
 
 def _recv_kernel_info(session: Session, sock: zmq.Socket, timeout: float) -> dict | None:
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
+    for _ in iter_timeout(timeout, default=timeout):
         if not sock.poll(50): continue
         try: _, msg = session.recv(sock, mode=0)
         except Exception: return None


### PR DESCRIPTION
## Summary
- Add timeout helpers (`parent_id`, `iter_timeout`, `wait_for_msg`) and apply them across kernel test utilities.
- Simplify several test-local timeout loops to use shared helpers.
- Use `asyncio.timeout` in gateway interrupt test and tighten iopub welcome loop.

## Tests
- pytest -q
- pytest -q -m slow
