### PR TITLE
Fix quadratic stream buffering in MiniStream

### DIFF
--- a/ipymini/term/__init__.py
+++ b/ipymini/term/__init__.py
@@ -1,8 +1,8 @@
 "Thread-local IO and display capture utilities for ipymini."
 
 from .io import StdinNotImplementedError, io_state, thread_local_io
-from .streams import MiniStream
+from .streams import MiniStream, coalesce_streams
 from .ipython_capture import IPythonCapture
 
-__all__ = ["io_state", "thread_local_io", "StdinNotImplementedError", "MiniStream", "IPythonCapture"]
+__all__ = ["io_state", "thread_local_io", "StdinNotImplementedError", "MiniStream", "coalesce_streams", "IPythonCapture"]
 __version__ = "0.0.0"

--- a/ipymini/term/ipython_capture.py
+++ b/ipymini/term/ipython_capture.py
@@ -4,7 +4,7 @@ from typing import Callable
 
 from .display import MiniDisplayHook, MiniDisplayPublisher
 from .io import thread_local_io
-from .streams import MiniStream
+from .streams import MiniStream, coalesce_streams
 
 log = logging.getLogger("ipymini.term")
 
@@ -62,7 +62,7 @@ class IPythonCapture:
         return self._dedupe_set_next_input(payload)
 
     def snapshot(self, *, result=None, result_metadata=None, execution_count=None) -> dict:
-        streams = [] if self.stream_sender is not None else list(self.stream_events)
+        streams = [] if self.stream_sender is not None else coalesce_streams(self.stream_events)
         display_events = [] if self.display_sender is not None else list(self.shell.display_pub.events)
         if result is None: result = self.shell.displayhook.last
         if result_metadata is None: result_metadata = self.shell.displayhook.last_metadata or {}

--- a/ipymini/term/streams.py
+++ b/ipymini/term/streams.py
@@ -1,3 +1,4 @@
+from itertools import groupby
 from typing import Callable
 
 
@@ -7,7 +8,7 @@ class MiniStream:
         self.name = name
         self.events = events
         self.sink = sink
-        self.buffer = ""
+        self.buffer = []
 
     def write(self, value) -> int:
         "Write text to buffer or emit live output."
@@ -18,8 +19,7 @@ class MiniStream:
         if not text: return 0
         if self.sink is not None: self._emit_live(text)
         if self.events is None: return len(text)
-        if self.events and self.events[-1]["name"] == self.name: self.events[-1]["text"] += text
-        else: self.events.append({"name": self.name, "text": text})
+        self.events.append({"name": self.name, "text": text})
         return len(text)
 
     def writelines(self, lines) -> int:
@@ -32,14 +32,19 @@ class MiniStream:
         "Flush buffered text to the sink."
         if self.sink is None: return None
         if self.buffer:
-            self.sink(self.name, self.buffer)
-            self.buffer = ""
+            self.sink(self.name, "".join(self.buffer))
+            self.buffer = []
         return None
 
     def isatty(self) -> bool: return False
 
     def _emit_live(self, text: str):
-        self.buffer += text
-        if self.buffer.endswith("\n"):
-            self.sink(self.name, self.buffer)
-            self.buffer = ""
+        self.buffer.append(text)
+        if text.endswith("\n"):
+            self.sink(self.name, "".join(self.buffer))
+            self.buffer = []
+
+
+def coalesce_streams(events: list[dict]) -> list[dict]:
+    "Merge adjacent same-name stream events into one event each."
+    return [dict(name=name, text="".join(e["text"] for e in grp)) for name, grp in groupby(events, key=lambda e: e["name"])]

--- a/tests/term/test_stream_perf.py
+++ b/tests/term/test_stream_perf.py
@@ -1,0 +1,35 @@
+import time
+
+from ipymini.term import MiniStream
+
+
+def _timed(fn) -> float:
+    t0 = time.monotonic()
+    fn()
+    return time.monotonic() - t0
+
+
+def test_many_small_writes_without_newline_are_linear():
+    "Progress-bar style output (no trailing newline) must not buffer quadratically."
+    n = 500_000
+
+    sink_chunks = []
+    live = MiniStream("stdout", None, sink=lambda name, text: sink_chunks.append(text))
+
+    def _write_live():
+        for _ in range(n): live.write("x")
+        live.flush()
+
+    elapsed = _timed(_write_live)
+    assert "".join(sink_chunks) == "x" * n
+    assert elapsed < 1.0, f"live buffering took {elapsed:.2f}s for {n} writes; O(n^2) string concat"
+
+    events = []
+    buffered = MiniStream("stdout", events)
+
+    def _write_buffered():
+        for _ in range(n): buffered.write("x")
+
+    elapsed = _timed(_write_buffered)
+    assert sum(len(e["text"]) for e in events) == n
+    assert elapsed < 1.0, f"buffered events took {elapsed:.2f}s for {n} writes; O(n^2) string concat"

--- a/tests/term/test_streams.py
+++ b/tests/term/test_streams.py
@@ -1,4 +1,4 @@
-from ipymini.term import MiniStream
+from ipymini.term import MiniStream, coalesce_streams
 
 
 def test_ministream_behaviors():
@@ -7,7 +7,8 @@ def test_ministream_behaviors():
     stream.write("hello")
     stream.write(" world\n")
     stream.write("again")
-    assert events == [dict(name="stdout", text="hello world\nagain")]
+    # Events are recorded one-per-write; consumers coalesce adjacent same-name events.
+    assert coalesce_streams(events) == [dict(name="stdout", text="hello world\nagain")]
 
     seen = []
     def sink(name: str, text: str): seen.append((name, text))
@@ -22,10 +23,11 @@ def test_ministream_behaviors():
     out = MiniStream("stdout", events)
     err = MiniStream("stderr", events)
     out.write("a")
+    out.write("a2")
     err.write("b")
     out.write("c")
-    assert events == [
-        {"name": "stdout", "text": "a"},
+    assert coalesce_streams(events) == [
+        {"name": "stdout", "text": "aa2"},
         {"name": "stderr", "text": "b"},
         {"name": "stdout", "text": "c"}]
 


### PR DESCRIPTION
The change makes sense, indeed  `+=` here is on strings, and coalesce_streams is nice touch.
