### PR TITLE
Fix IOPub status starvation behind sustained output

### DIFF
--- a/ipymini/zmqthread/iopub.py
+++ b/ipymini/zmqthread/iopub.py
@@ -14,28 +14,25 @@ class IOPubThread(ServiceThread):
         self.addr = addr
         self.session = session
         self.sndhwm = sndhwm
-        self.priority_q = queue.Queue()
-        self.q = queue.Queue(maxsize=int(qmax))
+        self.qmax = int(qmax)
+        self.q = queue.Queue()
         self.enqueued = 0
+        self.dropped = 0
         self.sent = 0
         self.send_errors = 0
 
     def send(self, msg_type, content, parent, metadata=None, ident=None, buffers=None):
-        "Queue an IOPub message for send; never drop status messages."
+        "Queue an IOPub message in FIFO order; drop non-status output past qmax, never status."
         self.enqueued += 1
-        item = (msg_type, content, parent, metadata, ident, buffers)
-        try: self.q.put_nowait(item)
-        except queue.Full:
-            if msg_type == "status":
-                self.priority_q.put(item)
-                return
-            backlog = self.enqueued - self.sent
-            if backlog in (100, 500, 1000): log.warning("IOPub queue full; dropping non-critical output. enq=%d sent=%d", self.enqueued, self.sent)
+        if msg_type != "status" and self.q.qsize() >= self.qmax:
+            self.dropped += 1
+            if self.dropped == 1 or self.dropped % 1000 == 0:
+                log.warning("IOPub queue full; dropping non-critical output. dropped=%d enq=%d sent=%d", self.dropped, self.enqueued, self.sent)
+            return
+        self.q.put_nowait((msg_type, content, parent, metadata, ident, buffers))
 
     def _get_next(self):
         try: return self.q.get(timeout=0.05)
-        except queue.Empty: pass
-        try: return self.priority_q.get_nowait()
         except queue.Empty: return None
 
     def run_service(self):

--- a/tests/zmqthread/test_iopub_status.py
+++ b/tests/zmqthread/test_iopub_status.py
@@ -1,0 +1,39 @@
+import zmq
+from jupyter_client.session import Session
+
+from ipymini.zmqthread import IOPubThread
+
+
+def _drive(iopub, max_steps: int = 60) -> list[str]:
+    "Pop queued messages like run_service does, while user code keeps printing."
+    popped = []
+    for step in range(max_steps):
+        item = iopub._get_next()
+        if item is None: break
+        popped.append(item[0])
+        if popped[-1] == "status": break
+        iopub.send("stream", dict(name="stdout", text=f"more{step}"), parent=None)
+    return popped
+
+
+def test_status_not_starved_by_sustained_output():
+    "A status queued while the queue is full must still go out under sustained stream traffic."
+    ctx = zmq.Context.instance()
+    iopub = IOPubThread(ctx, "tcp://127.0.0.1:1", Session(key=b""), qmax=4)  # not started: drive directly
+    for i in range(4): iopub.send("stream", dict(name="stdout", text=f"chunk{i}"), parent=None)
+    iopub.send("status", dict(execution_state="idle"), parent=None)
+    popped = _drive(iopub)
+    assert "status" in popped, f"status starved behind stream traffic: {popped}"
+
+
+def test_full_queue_drops_streams_but_keeps_order_and_status():
+    ctx = zmq.Context.instance()
+    iopub = IOPubThread(ctx, "tcp://127.0.0.1:1", Session(key=b""), qmax=2)
+    for i in range(5): iopub.send("stream", dict(name="stdout", text=f"chunk{i}"), parent=None)
+    iopub.send("status", dict(execution_state="idle"), parent=None)
+    iopub.send("status", dict(execution_state="busy"), parent=None)
+    got = []
+    while (item := iopub._get_next()) is not None: got.append((item[0], item[1].get("text") or item[1].get("execution_state")))
+    assert got == [("stream", "chunk0"), ("stream", "chunk1"), ("status", "idle"), ("status", "busy")]
+    assert iopub.enqueued == 7
+    assert iopub.dropped == 3

--- a/tests/zmqthread/test_zmqthread.py
+++ b/tests/zmqthread/test_zmqthread.py
@@ -82,10 +82,10 @@ def test_zmqthread_features():
 
     iopub = IOPubThread(ctx, f"tcp://127.0.0.1:{_free_port()}", session, qmax=1)
     iopub.send("stream", {"name": "stdout", "text": "one"}, parent=None)
-    iopub.send("stream", {"name": "stdout", "text": "two"}, parent=None)
-    iopub.send("status", {"execution_state": "idle"}, parent=None)
-    assert iopub.q.qsize() == 1
-    assert iopub.priority_q.qsize() == 1
+    iopub.send("stream", {"name": "stdout", "text": "two"}, parent=None)  # dropped: q full at qmax=1
+    iopub.send("status", {"execution_state": "idle"}, parent=None)        # status always queued
+    assert iopub.q.qsize() == 2
+    assert iopub.dropped == 1
     assert iopub.enqueued == 3
 
     router = None


### PR DESCRIPTION
Fixes a stability bug where a **successful cell can leave the kernel looking permanently "busy"**.

[To replicate in solveit](https://share.solveit.pub/d/2cdda964204e1570c4904e5fcf06007c)

<img width="553" height="439" alt="stuck busy" src="https://github.com/user-attachments/assets/602e1b3f-c00a-4c7f-897f-8d0858cf5ac3" />

## The issue

All IOPub traffic goes through one **bounded** queue in [`IOPubThread`](https://github.com/AnswerDotAI/ipymini/blob/main/ipymini/zmqthread/iopub.py) (`qmax`, default 10000); excess *non-critical* output is dropped. `status` must **not** be dropped — the **busy → idle** transition is how the frontend knows a cell finished — so when the main queue is full, `status` is diverted to a second `priority_q`:

```python
def send(self, msg_type, content, parent, ...):
    try: self.q.put_nowait(item)                  # main queue
    except queue.Full:
        if msg_type == "status": self.priority_q.put(item); return   # status parked here

def _get_next(self):
    try: return self.q.get(timeout=0.05)          # main queue FIRST
    except queue.Empty: pass
    try: return self.priority_q.get_nowait()      # priority queue ONLY when main is empty
    except queue.Empty: return None
```

**Despite its name, `priority_q` is read *last*** — only after the main queue has been empty for 50 ms. The status it holds *is* eventually delivered, but **out of order**: it jumps to the very end, behind everything still in the main queue. That reordering is the bug.

## The sequence that sticks

The shell `execute_reply` returns as soon as the cell finishes, so the **next cell starts running while the previous cell's IOPub backlog is still draining**:

```
run A:  for i in range(10_000): print(i)
  send busy(A)        q has room    → main q     → delivered
  10_000 prints       q fills        → excess dropped
  A ends: send idle(A) q is FULL     → priority_q            [parked: idle_A]
  execute_reply(A) returns on the shell channel        (A "done" from shell's view)

run B:  1 + 1         (starts immediately; q still full from A's backlog)
  send busy(B)        q STILL FULL   → priority_q            [parked: idle_A, busy_B]
  B ends: send idle(B) q has room    → main q     (consumer drained some by now)

consumer drains FIFO:
  …A's backlog…, idle(B)            → main q emptied
  q empty → drain priority_q:  idle(A) , then busy(B)        ← busy(B) is the LAST status
```

So B's `busy` and `idle` are themselves reordered and the **final status the frontend receives is a stale `busy`**. that reset `idle_evt` the next cell never runs waiting on idle_evt.

## The fix ([`8fe1793`](https://github.com/AnswerDotAI/ipymini/commit/8fe1793))

Use a **single FIFO** queue. `status` is always enqueued; non-`status` output is dropped at the front door once the backlog reaches `qmax`:

```python
def send(self, msg_type, content, parent, ...):
    self.enqueued += 1
    if msg_type != "status" and self.q.qsize() >= self.qmax:
        self.dropped += 1
        if self.dropped == 1 or self.dropped % 1000 == 0: log.warning("IOPub queue full; dropping ...")
        return
    self.q.put_nowait((msg_type, content, parent, metadata, ident, buffers))

def _get_next(self):
    try: return self.q.get(timeout=0.05)
    except queue.Empty: return None
```

One queue ⇒ **status can never be reordered past later messages**. `busy`/`idle` are delivered in exactly the order produced.