### PR TITLE
Eliminate ~40ms latency on every shell/control reply

### DIFF
--- a/ipymini/zmqthread/async_router.py
+++ b/ipymini/zmqthread/async_router.py
@@ -1,6 +1,6 @@
-import asyncio, logging, sys, time, traceback
+import asyncio, contextlib, logging, sys, time, traceback
 from fastcore.basics import nested_idx
-from microio import LoopServiceThread
+from microio import EndOfStream, LoopServiceThread
 import zmq, zmq.asyncio
 
 from .queues import ThreadBoundAsyncQueue
@@ -23,6 +23,7 @@ class AsyncRouterThread(LoopServiceThread):
 
         self.sock = None
         self.outbox = ThreadBoundAsyncQueue()
+        self.wake_item = None  # one reply pulled by the wakeup waiter, not yet sent
         self.enqueued = 0
         self.sent = 0
         self.send_errors = 0
@@ -62,10 +63,23 @@ class AsyncRouterThread(LoopServiceThread):
         self.sock = sock
         self.started()
 
+        get_task = None
         try:
             while not self.scope.closed:
                 await self._drain_outbox(sock)
-                try: ready = await sock.poll(timeout=self.poll_ms, flags=zmq.POLLIN)
+                # Wait on the outbox and the socket together so a reply enqueued from a subshell
+                # thread wakes the loop at once instead of waiting out the poll timeout.
+                if get_task is None: get_task = asyncio.ensure_future(self._next_outbox_item())
+                poll_fut = asyncio.ensure_future(sock.poll(timeout=self.poll_ms, flags=zmq.POLLIN))
+                done, _ = await asyncio.wait({get_task, poll_fut}, return_when=asyncio.FIRST_COMPLETED)
+                if get_task in done:
+                    if (item := get_task.result()) is not None: self.wake_item = item
+                    get_task = None
+                if poll_fut not in done:
+                    poll_fut.cancel()
+                    with contextlib.suppress(asyncio.CancelledError): await poll_fut
+                    continue
+                try: ready = poll_fut.result()
                 except zmq.ZMQError as exc:
                     if not self.scope.closed:
                         log.exception("%s router stopped while polling", self.log_label)
@@ -75,22 +89,33 @@ class AsyncRouterThread(LoopServiceThread):
                 await self._handle_recv(sock)
         except asyncio.CancelledError: return
         finally:
+            if get_task is not None: get_task.cancel()
             try: sock.close(0)
             except Exception:
                 if not self.scope.closed: log.exception("%s router socket close failed", self.log_label)
 
+    async def _next_outbox_item(self):
+        "Await the next queued reply; None once the outbox is closed."
+        try: return await self.outbox.get()
+        except EndOfStream: return None
+
     async def _drain_outbox(self, sock: zmq.asyncio.Socket):
-        for item in self.outbox.drain_nowait(max_items=self.max_send_batch):
-            msg_type, content, parent, idents = item
-            msg = self.session.msg(msg_type, content, parent=parent)
-            frames = self.session.serialize(msg, ident=idents)
-            try:
-                fut = sock.send_multipart(frames)
-                if asyncio.isfuture(fut): await fut
-                self.sent += 1
-            except Exception as exc:
-                self.send_errors += 1
-                log.error("%s send error: %s", self.log_label, exc, exc_info=exc)
+        if self.wake_item is not None:
+            item, self.wake_item = self.wake_item, None
+            await self._send_item(sock, item)
+        for item in self.outbox.drain_nowait(max_items=self.max_send_batch): await self._send_item(sock, item)
+
+    async def _send_item(self, sock: zmq.asyncio.Socket, item):
+        msg_type, content, parent, idents = item
+        msg = self.session.msg(msg_type, content, parent=parent)
+        frames = self.session.serialize(msg, ident=idents)
+        try:
+            fut = sock.send_multipart(frames)
+            if asyncio.isfuture(fut): await fut
+            self.sent += 1
+        except Exception as exc:
+            self.send_errors += 1
+            log.error("%s send error: %s", self.log_label, exc, exc_info=exc)
 
     async def _handle_recv(self, sock: zmq.asyncio.Socket):
         try: msg_list = await sock.recv_multipart(copy=False)

--- a/tests/zmqthread/test_router_latency.py
+++ b/tests/zmqthread/test_router_latency.py
@@ -1,0 +1,72 @@
+import statistics, threading, time
+
+import zmq
+from jupyter_client.session import Session
+
+from ipymini.zmqthread import AsyncRouterThread
+from .test_zmqthread import _free_port, _poll_recv
+
+
+def _started_router(handler):
+    ctx = zmq.Context.instance()
+    router = AsyncRouterThread(context=ctx, session=Session(key=b""), bind_addr=f"tcp://127.0.0.1:{_free_port()}", handler=handler, log_label="shell")
+    router.start()
+    router.wait_started(2)
+    dealer = ctx.socket(zmq.DEALER)
+    dealer.linger = 0
+    dealer.connect(router.bind_addr)
+    time.sleep(0.05)
+    return router, dealer
+
+
+def test_reply_enqueued_from_other_thread_is_sent_promptly():
+    "Replies must not wait out the router's poll timeout (kernel replies come from subshell threads)."
+    got = {}
+    seen = threading.Event()
+
+    def handler(msg, idents):
+        got.update(msg=msg, idents=idents)
+        seen.set()
+
+    router, dealer = _started_router(handler)
+    client = Session(key=b"")
+    try:
+        client.send(dealer, "kernel_info_request", {}, parent=None)
+        assert seen.wait(2)
+        lats = []
+        for _ in range(10):
+            time.sleep(0.01)  # let the router settle into its idle wait
+            t0 = time.monotonic()
+            router.enqueue(("kernel_info_reply", dict(status="ok"), got["msg"], got["idents"]))
+            _poll_recv(dealer, client, timeout=2000)
+            lats.append(time.monotonic() - t0)
+        median = statistics.median(lats)
+        assert median < router.poll_ms / 1000 / 4, f"reply latency {median*1000:.1f}ms; outbox does not wake the poll loop"
+    finally:
+        router.stop()
+        router.join(timeout=2)
+        dealer.close(0)
+
+
+def test_burst_replies_all_arrive_in_order():
+    "A burst larger than max_send_batch must all be delivered, in order, with no drops."
+    got = {}
+    seen = threading.Event()
+
+    def handler(msg, idents):
+        got.update(msg=msg, idents=idents)
+        seen.set()
+
+    router, dealer = _started_router(handler)
+    client = Session(key=b"")
+    try:
+        client.send(dealer, "kernel_info_request", {}, parent=None)
+        assert seen.wait(2)
+        n = 2 * router.max_send_batch + 50
+        for i in range(n): router.enqueue(("kernel_info_reply", dict(status="ok", i=i), got["msg"], got["idents"]))
+        received = [_poll_recv(dealer, client, timeout=2000)[1]["content"]["i"] for _ in range(n)]
+        assert received == list(range(n)), f"lost or reordered: got {len(received)} of {n}"
+    finally:
+        router.stop()
+        router.join(timeout=2)
+        dealer.close(0)


### PR DESCRIPTION

**Opus description:**
Handlers run on subshell threads and enqueue replies onto the outbox, but the router loop blocked in await sock.poll(timeout=50ms) waiting for a socket event. A cross-thread enqueue does not complete that poll, so every reply sat until the poll timed out (~40ms median measured). Wait on the outbox and the socket poll together via asyncio.wait(FIRST_COMPLETED) so an enqueued reply wakes the loop at once; the pulled item is stashed in wake_item and sent on the next drain. Adds tests/zmqthread/test_router_latency.py.