### PR TITLE
Fix subshell history namespace decoupling from parent shell

### DIFF
--- a/ipymini/shell/shell.py
+++ b/ipymini/shell/shell.py
@@ -77,6 +77,15 @@ def _init_ipython_app(shell):
         startup_done = True
 
 
+def _share_history(shell, parent):
+    """Point `shell`'s in-memory history at `parent`'s, then rebind In/Out in the shared user_ns (which `shell`'s init clobbered).
+    NB: shells keep independent execution counts, so if multiple shells store history, `In[n]`/`Out[n]` may not match prompt `n`."""
+    hm, phm = shell.history_manager, parent.history_manager
+    hm.input_hist_parsed,hm.input_hist_raw = phm.input_hist_parsed,phm.input_hist_raw
+    hm.output_hist,hm.output_hist_reprs,hm.dir_hist = phm.output_hist,phm.output_hist_reprs,phm.dir_hist
+    shell.init_user_ns()
+
+
 class MiniShell:
     def __init__(self, request_input: Callable[[str, bool], str], debug_event_callback: Callable[[dict], None] | None = None,
         zmq_context: zmq.Context | None = None, *, user_ns: dict | None = None, use_singleton: bool = True, exec_scopes=None,
@@ -86,7 +95,10 @@ class MiniShell:
 
         os.environ.setdefault("MPLBACKEND", "module://matplotlib_inline.backend_inline")
         if use_singleton: self.ipy = InteractiveShell.instance(user_ns=user_ns)
-        else: self.ipy = InteractiveShell(user_ns=user_ns)
+        else:
+            self.ipy = InteractiveShell(user_ns=user_ns)
+            if InteractiveShell.initialized() and user_ns is InteractiveShell.instance().user_ns:
+                _share_history(self.ipy, InteractiveShell.instance())
         use_jedi = _env_flag("IPYMINI_USE_JEDI")
         if use_jedi is not None: self.ipy.Completer.use_jedi = use_jedi
 

--- a/tests/kernel/test_subshells.py
+++ b/tests/kernel/test_subshells.py
@@ -225,6 +225,22 @@ def test_subshell_reads_shared_ns_during_parent_sleep(kc):
     _delete_subshell(kc, subshell_id)
 
 
+def test_subshell_creation_keeps_history_ns_linked(kc):
+    "Creating a subshell must not orphan In/Out in the shared user_ns from the parent's HistoryManager."
+    subshell_id = _create_subshell(kc)
+    try:
+        _, reply, _ = _execute(kc, "hist_probe = 42")
+        assert reply["content"]["status"] == "ok"
+        code = ("ip = get_ipython()\n"
+            "print(ip.user_ns['In'] is ip.history_manager.input_hist_parsed,"
+            " ip.user_ns['Out'] is ip.history_manager.output_hist, In[-2])")
+        _, reply, outputs = _execute(kc, code)
+        assert reply["content"]["status"] == "ok"
+        text = "".join(m["content"].get("text", "") for m in iopub_streams(outputs))
+        assert "True True hist_probe = 42" in text, f"history ns decoupled: {text!r}"
+    finally: _delete_subshell(kc, subshell_id)
+
+
 def test_subshell_interrupt_request_breaks_sleep(kc):
     subshell_id = _create_subshell(kc)
     msg_id = _send_execute(kc, "import time; time.sleep(0.7); print('done')", subshell_id=subshell_id)


### PR DESCRIPTION
## Problem

When a non-singleton `InteractiveShell` was created for a subshell sharing the parent's `user_ns`, the shell's init clobbered the `In`/`Out` bindings, orphaning them from the parent's `HistoryManager`. This meant subshell history
 was disconnected from the parent's input/output history.

## Fix

- Add `_share_history()` which re-points the subshell's `HistoryManager` in-memory histories (parsed, raw, output, reprs, dir) to the parent's, then rebinds `In`/`Out` in the shared `user_ns` via `init_user_ns()`.
- Call it in `MiniShell.__init__` when a non-singleton shell is created with a `user_ns` that matches the singleton instance's namespace.
- Add `test_subshell_creation_keeps_history_ns_linked` to verify `In`/`Out` remain linked to the parent's `HistoryManager` after subshell creation.

## Note
Shells keep independent execution counts, so \`In[n]\`/\`Out[n]\` may not match the prompt \`n\` if multiple shells store history.